### PR TITLE
Fix abs in Num instances of V1, V2, V3, and V4

### DIFF
--- a/src/Data/Array/Accelerate/Linear/V1.hs
+++ b/src/Data/Array/Accelerate/Linear/V1.hs
@@ -113,7 +113,7 @@ instance A.Num a => P.Num (Exp (V1 a)) where
   (*)             = lift2 ((*) :: V1 (Exp a) -> V1 (Exp a) -> V1 (Exp a))
   negate          = lift1 (negate :: V1 (Exp a) -> V1 (Exp a))
   signum          = lift1 (signum :: V1 (Exp a) -> V1 (Exp a))
-  abs             = lift1 (signum :: V1 (Exp a) -> V1 (Exp a))
+  abs             = lift1 (abs :: V1 (Exp a) -> V1 (Exp a))
   fromInteger x   = V1_ (P.fromInteger x)
 
 instance A.Floating a => P.Fractional (Exp (V1 a)) where

--- a/src/Data/Array/Accelerate/Linear/V2.hs
+++ b/src/Data/Array/Accelerate/Linear/V2.hs
@@ -153,7 +153,7 @@ instance A.Num a => P.Num (Exp (V2 a)) where
   (*)             = lift2 ((*) :: V2 (Exp a) -> V2 (Exp a) -> V2 (Exp a))
   negate          = lift1 (negate :: V2 (Exp a) -> V2 (Exp a))
   signum          = lift1 (signum :: V2 (Exp a) -> V2 (Exp a))
-  abs             = lift1 (signum :: V2 (Exp a) -> V2 (Exp a))
+  abs             = lift1 (abs :: V2 (Exp a) -> V2 (Exp a))
   fromInteger x   = lift (P.fromInteger x :: V2 (Exp a))
 
 instance A.Floating a => P.Fractional (Exp (V2 a)) where

--- a/src/Data/Array/Accelerate/Linear/V3.hs
+++ b/src/Data/Array/Accelerate/Linear/V3.hs
@@ -160,7 +160,7 @@ instance A.Num a => P.Num (Exp (V3 a)) where
   (*)             = lift2 ((*) :: V3 (Exp a) -> V3 (Exp a) -> V3 (Exp a))
   negate          = lift1 (negate :: V3 (Exp a) -> V3 (Exp a))
   signum          = lift1 (signum :: V3 (Exp a) -> V3 (Exp a))
-  abs             = lift1 (signum :: V3 (Exp a) -> V3 (Exp a))
+  abs             = lift1 (abs :: V3 (Exp a) -> V3 (Exp a))
   fromInteger x   = lift (P.fromInteger x :: V3 (Exp a))
 
 instance A.Floating a => P.Fractional (Exp (V3 a)) where

--- a/src/Data/Array/Accelerate/Linear/V4.hs
+++ b/src/Data/Array/Accelerate/Linear/V4.hs
@@ -225,7 +225,7 @@ instance A.Num a => P.Num (Exp (V4 a)) where
   (*)             = lift2 ((*) :: V4 (Exp a) -> V4 (Exp a) -> V4 (Exp a))
   negate          = lift1 (negate :: V4 (Exp a) -> V4 (Exp a))
   signum          = lift1 (signum :: V4 (Exp a) -> V4 (Exp a))
-  abs             = lift1 (signum :: V4 (Exp a) -> V4 (Exp a))
+  abs             = lift1 (abs :: V4 (Exp a) -> V4 (Exp a))
   fromInteger x   = lift (P.fromInteger x :: V4 (Exp a))
 
 instance A.Floating a => P.Fractional (Exp (V4 a)) where


### PR DESCRIPTION
The Num instances of `V1`, `V2`, `V3`, and `V4` had defined `abs = lift1 signum` which resulted in all elements of all vectors being either `-1`, `0`, or `1` after calling `abs`. This PR remedies that by defining `abs = lift1 abs` instead.